### PR TITLE
Two small improvements

### DIFF
--- a/src/Comment.php
+++ b/src/Comment.php
@@ -202,6 +202,16 @@ class Comment
         return $parser->decode($json, $assoc, $depth, $options);
     }
 
+    /**
+     * Return stripped and decoded JSON from file. Does not check if file exists.
+     *
+     * @param string $file
+     * @param bool   $assoc
+     * @param int    $depth
+     * @param int    $options
+     *
+     * @return string Stripped JSON from provided file
+     */
     public static function parseFromFile(string $file, bool $assoc = false, int $depth = 512, int $options = 0)
     {
         $json = \file_get_contents($file);

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -171,7 +171,7 @@ class Comment
      *
      * @return mixed
      */
-    public function decode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
+    public function decode(string $json, bool $assoc = false, int $depth = 512, int $options = 0): mixed
     {
         $decoded = \json_decode($this->strip($json), $assoc, $depth, $options);
 
@@ -191,7 +191,7 @@ class Comment
     /**
      * Static alias of decode().
      */
-    public static function parse(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
+    public static function parse(string $json, bool $assoc = false, int $depth = 512, int $options = 0): mixed
     {
         static $parser;
 
@@ -212,7 +212,7 @@ class Comment
      *
      * @return string Stripped JSON from provided file
      */
-    public static function parseFromFile(string $file, bool $assoc = false, int $depth = 512, int $options = 0)
+    public static function parseFromFile(string $file, bool $assoc = false, int $depth = 512, int $options = 0): mixed
     {
         $json = \file_get_contents($file);
 


### PR DESCRIPTION
These two are somewhat unrelated, but they are both so small I didn't want to create two separate PRs.

Docblock for parseFromFile, and setting return types for all public functions — including the ones return mixed datatype (e.g. from json_decode)